### PR TITLE
Add 'Top up' and user icons

### DIFF
--- a/src/components/CategoryIcon/index.js
+++ b/src/components/CategoryIcon/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import './style.scss';
 
-export default ({ category = 'general' }) => (
+export default ({ category }) => (
   <img className={`category--${category}-bg`} src={require(`./icons/${category}.svg`)} alt={category} width="100%" />
 );

--- a/src/components/Main/index.js
+++ b/src/components/Main/index.js
@@ -94,32 +94,61 @@ export default class Main extends React.Component {
     });
   }
 
+  processTransactionCategory(transaction) {
+    if (transaction.category) {
+      if (transaction.category === 'mondo' || transaction.category === 'monzo') {
+        return '';
+      }
+
+      return transaction.category;
+    }
+
+    return 'general';
+  }
+
+  processTransactionTitle(transaction) {
+    if (transaction.counterparty) {
+      if (typeof transaction.counterparty.name !== 'undefined') {
+        return transaction.counterparty.name;
+      }
+
+      if (typeof transaction.counterparty.number !== 'undefined') {
+        return transaction.counterparty.number;
+      }
+    }
+
+    if (transaction.merchant && typeof transaction.merchant.name !== 'undefined') {
+      return transaction.merchant.name;
+    }
+
+    // if is top up
+    if (transaction.is_load) {
+      return 'Top up';
+    }
+
+    return '';
+  }
+
+  processTransactionAmount(transaction) {
+    return intToAmount(transaction.amount, transaction.currency);
+  }
+
+  processTransactionLocalAmount(transaction) {
+    if (transaction.local_currency !== this.state.currency) {
+      return intToAmount(transaction.local_amount, transaction.local_currency);
+    }
+
+    return false;
+  }
+
   processTransactionsData(transactions) {
     transactions = transactions.map(transaction => {
-
-      let title = '';
-
-      if (transaction.counterparty && typeof transaction.counterparty.name !== 'undefined') {
-        title = transaction.counterparty.name;
-      } else if (transaction.merchant && typeof transaction.merchant.name !== 'undefined') {
-        title = transaction.merchant.name;
-      } else if (transaction.is_load) {
-        title = 'Monzo';
-      }
-
-      const amount = intToAmount(transaction.amount, transaction.currency);
-
-      let localAmount = false;
-
-      if (transaction.local_currency !== this.state.currency) {
-        localAmount = intToAmount(transaction.local_amount, transaction.local_currency);
-      }
-
       return {
         ...transaction,
-        title,
-        amount,
-        localAmount
+        category: this.processTransactionCategory(transaction),
+        title: this.processTransactionTitle(transaction),
+        amount: this.processTransactionAmount(transaction),
+        localAmount: this.processTransactionLocalAmount(transaction)
       };
     });
 

--- a/src/components/Transaction/index.js
+++ b/src/components/Transaction/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import TransactionImage from 'components/TransactionImage';
 import CategoryIcon from 'components/CategoryIcon';
 import { getDeclineTranslation } from 'lib/utils';
 
@@ -25,8 +26,6 @@ export default class Transaction extends React.Component {
       transaction: {
         id,
         title,
-        category,
-        merchant,
         created,
         decline_reason,
         amount,
@@ -39,7 +38,7 @@ export default class Transaction extends React.Component {
       <a href="#" className={`collection-item avatar row ${active === id ? 'active' : ''}`} onClick={this.handleClick}>
         <div className="col s10">
           <div className="rounded circle">
-            {merchant && merchant.logo ? <img src={merchant.logo} alt={title} width="100%" /> : <CategoryIcon category={category} />}
+            <TransactionImage transaction={transaction} />
           </div>
           <span className="title primary-text">{title}{localAmount ? ' 🌎' : ''}</span>
           {decline_reason ? (

--- a/src/components/TransactionImage/index.js
+++ b/src/components/TransactionImage/index.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import CategoryIcon from 'components/CategoryIcon';
+import { mapRange } from 'lib/utils';
+
+export default class TransactionImage extends React.Component {
+  nameToHue(name) {
+    const MIN_CHAR_CODE = 65;
+    const MAX_CHAR_CODE = 90;
+
+    const MIN_HUE = 0;
+    const MAX_HUE = 360;
+
+    return mapRange(name.charCodeAt(0), MIN_CHAR_CODE, MAX_CHAR_CODE, MIN_HUE, MAX_HUE);
+  }
+
+  render() {
+    const {
+      transaction,
+      transaction: {
+        title,
+        category,
+        counterparty,
+        merchant
+      },
+      large
+    } = this.props;
+
+    if (transaction.is_load) {
+      const styles = {
+        height: '100%',
+        color: 'white',
+        textAlign: 'center',
+        paddingTop: '0.05em',
+        fontSize: large ? '5.5em' : '2.5em',
+        lineHeight: '100%'
+      };
+
+      let background = 'hsl(145, 37%, 50%)';
+      let symbol = '+';
+
+      if (counterparty) {
+        if (counterparty.number) {
+          background = '#878787';
+          symbol = '#';
+        }
+
+        if (counterparty.name) {
+          const name = counterparty.name.toUpperCase();
+
+          background = `hsl(${this.nameToHue(name)}, 37%, 50%)`;
+
+          symbol = name.charAt(0);
+        }
+      }
+
+      styles.background = background
+
+      return <div style={styles}>{symbol}</div>;
+    }
+
+    if (merchant && merchant.logo) {
+      return <img src={merchant.logo} alt={title} width="100%" />;
+    }
+
+    return <CategoryIcon category={category} />;
+  }
+}

--- a/src/components/TransactionSummary/index.js
+++ b/src/components/TransactionSummary/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import TransactionImage from 'components/TransactionImage';
 import CategoryIcon from 'components/CategoryIcon';
 import { getDeclineTranslation, isEmpty } from 'lib/utils';
 import './style.scss';
@@ -44,7 +45,7 @@ export default class TransactionSummary extends React.Component {
         <div className="transaction--overview">
           {Map}
           <div className="transaction--overview--logo">
-            {merchant && merchant.logo ? <img src={merchant.logo} alt={title} width="100%" /> : <CategoryIcon category={category} />}
+            <TransactionImage transaction={transaction} large={true} />
           </div>
           <span className={`transaction--amount ${(amount && amount.includes('+')) ? 'green-text' : 'black-text'}`}>
             {amount}{localAmount ? <span className="grey-text text-lighten-1"> / {localAmount}</span> : ''}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -2,6 +2,10 @@
 import currencyCodes from 'lib/currency-codes.json';
 import 'whatwg-fetch';
 
+export function mapRange(value, low1, high1, low2, high2) {
+  return low2 + (high2 - low2) * (value - low1) / (high1 - low1);
+}
+
 export function isEmpty(obj) {
   return Object.keys(obj).length === 0 && obj.constructor === Object;
 }

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -47,6 +47,10 @@ body {
   margin: 0 auto;
 }
 
+.green-text {
+  color: #50af78 !important;
+}
+
 .primary-text {
   color: $primary-color;
 }


### PR DESCRIPTION
Closes #44 

This adds a new image component named `TransactionImage` this component has new icons for things not currently handled.

Top up:
![image](https://cloud.githubusercontent.com/assets/2591901/21957037/438d89c0-da86-11e6-8906-67726e1a8e99.png)

Money sent to another account with a number:
![image](https://cloud.githubusercontent.com/assets/2591901/21957047/5c0f6b58-da86-11e6-9c3b-d74e85c99d69.png)

Money recieved from another user:
![image](https://cloud.githubusercontent.com/assets/2591901/21957059/7b46040a-da86-11e6-9b42-c83fc3dde8d6.png)
